### PR TITLE
fix: pause state did not resume after end time

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		utils.CheckError(err)
 
 	case "pause":
-		scmd.Pause(statusPath)
+		scmd.Pause(nil, statusPath)
 
 	default:
 		utils.HelpUsage()


### PR DESCRIPTION
The problem is that when we already hit or exceed the end time of pomodoro timer and we are resuming from the paused state, the timer will immediately finish, even though there's still time left when we pause the timer.

The cause of the problem is because when we already hit or exceed the end time, we only updating the `PausePoint` to `nil` and not updating the `EndTime`. When we resume the timer, we should update the `EndTime` with the current time extended by the remaining duration from `PausePoint`.

Let's say we paused at 5:30 A.M and the `EndTime` is 5:40 A.M, which means we have 10 minutes left. When we hit 5:45 A.M and resume the timer, we should update the `EndTime` to 5:55 A.M (extending 5:45 by 10 minutes).

With that in mind, move the conditional check for expired `EndTime` after the check for `PausePoint` so that we don't messed up with the resume condition and still able to _not_ enter pause state when the `EndTime` already expired.